### PR TITLE
Reset de senha e mais informações de erros

### DIFF
--- a/api.py
+++ b/api.py
@@ -19,6 +19,8 @@ class SignUpForm(BaseModel):
   password: str
   displayName: Optional[str] = None
 
+class ResetPasswordForm(BaseModel):
+  email: str
 
 app = FastAPI()
 
@@ -58,6 +60,18 @@ def login(credentials: HTTPBasicCredentials = Depends(security)):
 @app.put('/user/', status_code=200)
 async def update_profile(displayName: str = Form(...), user_id: str = Header(...), token: str = Header(...), file: UploadFile = File(...)):
   result = pc.update_user(user_id, token, displayName, file)
+  
+  if result == 200:
+    return {'status': 'success'}
+  else:
+    return {
+      'status': 'fail',
+      'data': result
+    }
+
+@app.post('/resetpassword/', status_code=200)
+def reset_password(reset_password_form: ResetPasswordForm):
+  result = pc.change_password(reset_password_form.email)
   
   if result == 200:
     return {'status': 'success'}

--- a/api.py
+++ b/api.py
@@ -56,13 +56,16 @@ def login(credentials: HTTPBasicCredentials = Depends(security)):
   }
 
 @app.put('/user/', status_code=200)
-async def change_profile_pic(displayName: str = Form(...), user_id: str = Header(...), token: str = Header(...), file: UploadFile = File(...)):
+async def update_profile(displayName: str = Form(...), user_id: str = Header(...), token: str = Header(...), file: UploadFile = File(...)):
   result = pc.update_user(user_id, token, displayName, file)
   
   if result == 200:
     return {'status': 'success'}
   else:
-    return {'status': 'fail'}
+    return {
+      'status': 'fail',
+      'data': result
+    }
 
 @app.post('/uploadfile/', status_code=201)
 async def create_upload_file(user_id: str = Header(...), token: str = Header(...), file: UploadFile = File(...)):

--- a/modules/pyrebase_connector.py
+++ b/modules/pyrebase_connector.py
@@ -88,7 +88,7 @@ class PyrebaseConnector(object):
     except Exception as e:
       _error_json = e.args[1]
       _error = json.loads(_error_json)['error']
-      return _error['message']
+      return _error
 
   def change_password(self, email):
     try:


### PR DESCRIPTION
# Reset de senha e mais informações de erros

Foi desenvolvida uma nova rota na API para fornecer a funcionalidade de redefinição de senha do usuário, além de também 
terem sido acrescentados mais detalhes de erros à rota de update de informações do usuário, visto que antes só falava que deu erro.