### PR TITLE
Update pdfConverter.py

### DIFF
--- a/modules/pdfConverter.py
+++ b/modules/pdfConverter.py
@@ -41,6 +41,6 @@ def pdfConverter(input_path, output_path='images', form='png', dpi=300, poppler_
 
         for i, im in enumerate(images):
             final_name = f'{output_path}/{filename}/{i:02d}.{form}'
-            if not os.path.isfile(final_name): im.save()
+            if not os.path.isfile(final_name): im.save(final_name)
     
     return images


### PR DESCRIPTION
A função de save das imagens geradas a partir do PDF estava sem seu parâmetro de file_name e estava quebrando a execução. Agora isto foi corrigido.